### PR TITLE
Leistungsschutzrecht

### DIFF
--- a/u/urhg/index.md
+++ b/u/urhg/index.md
@@ -2581,9 +2581,11 @@ eines Leistungsschutzberechtigten geltend gemacht werden, dessen Werk oder
 nach diesem Gesetz geschützter Schutzgegenstand im Presseerzeugnis enthalten
 ist.
 
-(4) Zulässig ist die öffentliche Zugänglichmachung von Presseerzeugnissen,
-soweit sie nicht durch die Anbieter von Suchmaschinen erfolgt. Im Übrigen
-gelten die Vorschriften des Teils 1 Abschnitt 6 entsprechend.
+(4) Zulässig ist die öffentliche Zugänglichmachung von Presseerzeugnissen oder
+Teilen hiervon, soweit sie nicht durch gewerbliche Anbieter von Suchmaschinen
+oder gewerbliche Anbieter von Diensten erfolgt, die Inhalte entsprechend
+aufbereiten. Im Übrigen gelten die Vorschriften des Teils 1 Abschnitt 6
+entsprechend.
 
 
 #### § 87h Beteiligungsanspruch des Urhebers

--- a/u/urhg/index.md
+++ b/u/urhg/index.md
@@ -2548,6 +2548,50 @@ Auswertung der Datenbank zuwiderlaufen noch die berechtigten
 Interessen des Datenbankherstellers unzumutbar beeinträchtigen.
 
 
+### Abschnitt 7 - Schutz des Presseverlegers
+
+
+#### § 87f Presseverleger
+
+(1) Der Hersteller eines Presseerzeugnisses Presseverleger) hat das
+ausschließliche Recht, das Presseerzeugnis oder Teile hiervon zu gewerblichen
+Zwecken öffentlich zugänglich zu machen. Ist das Presseerzeugnis in einem
+Unternehmen hergestellt worden, so gilt der Inhaber des Unternehmens als
+Hersteller.
+
+(2) Ein Presseerzeugnis ist die redaktionell-technische Festlegung
+journalistischer Beiträge im Rahmen einer unter einem Titel auf beliebigen
+Trägern periodisch veröffentlichten Sammlung, die bei Würdigung der
+Gesamtumstände als überwiegend verlagstypisch anzusehen ist und die nicht
+überwiegend der Eigenwerbung dient. Journalistische Beiträge sind
+insbesondere Artikel und Abbildungen, die der Informationsvermittlung,
+Meinungsbildung oder Unterhaltung dienen.
+
+
+#### § 87g Übertragbarkeit, Dauer und Schranken des Rechts
+
+(1) Das Recht des Presseverlegers nach § 87f Absatz 1 Satz 1 ist übertragbar.
+Die §§ 31 und 33 gelten entsprechend.
+
+(2) Das Recht erlischt ein Jahr nach der Veröffentlichung des
+Presseerzeugnisses.
+
+(3) Das Recht des Pressverlegers kann nicht zum Nachteil des Urhebers oder
+eines Leistungsschutzberechtigten geltend gemacht werden, dessen Werk oder
+nach diesem Gesetz geschützter Schutzgegenstand im Presseerzeugnis enthalten
+ist.
+
+(4) Zulässig ist die öffentliche Zugänglichmachung von Presseerzeugnissen für
+nicht gewerbliche Zwecke. Im Übrigen gelten die Vorschriften des Teils 1
+Abschnitt 6 entsprechend.
+
+
+#### § 87h Beteiligungsanspruch des Urhebers
+
+Der Urheber ist an einer Vergütung angemessen zu beteiligen.
+
+
+
 ## Teil 3 - Besondere Bestimmungen für Filme
 
 

--- a/u/urhg/index.md
+++ b/u/urhg/index.md
@@ -2581,9 +2581,9 @@ eines Leistungsschutzberechtigten geltend gemacht werden, dessen Werk oder
 nach diesem Gesetz geschützter Schutzgegenstand im Presseerzeugnis enthalten
 ist.
 
-(4) Zulässig ist die öffentliche Zugänglichmachung von Presseerzeugnissen für
-nicht gewerbliche Zwecke. Im Übrigen gelten die Vorschriften des Teils 1
-Abschnitt 6 entsprechend.
+(4) Zulässig ist die öffentliche Zugänglichmachung von Presseerzeugnissen,
+soweit sie nicht durch die Anbieter von Suchmaschinen erfolgt. Im Übrigen
+gelten die Vorschriften des Teils 1 Abschnitt 6 entsprechend.
 
 
 #### § 87h Beteiligungsanspruch des Urhebers


### PR DESCRIPTION
# Entwurf eines Siebenten Gesetzes zur Änderung des Urheberrechtsgesetzes

Bearbeitungsstand: 27.07.2012 10:14 Uhr
## A. Problem und Ziel

Durch den Gesetzentwurf soll sichergestellt werden, dass
Presseverlage im Online-Bereich nicht schlechtergestellt sind als
andere Werkvermittler. Um den Schutz von Presseerzeugnissen im
Internet zu verbessern, soll ein Leistungsschutzrecht für
Presseverlage eingeführt werden.
## B. Lösung

Es werden folgende Änderungen des Urheberrechtsgesetzes (UrhG) vorgeschlagen:

Mit dem Leistungsschutzrecht für Presseverlage wird den Presseverlagen das
ausschließliche Recht eingeräumt, Presseerzeugnisse zu gewerblichen Zwecken im
Internet öffentlich zugänglich zu machen. Jedoch ist ein Schutz nur vor
systematischen Zugriffen auf die verlegerische Leistung durch die Anbieter von
Suchmaschinen geboten, da deren Geschäftsmodell in besonderer Weise darauf
ausgerichtet ist, für die eigene Wertschöpfung auf die verlegerische Leistung
zuzugreifen. Nicht erfasst werden deshalb andere Nutzer, wie z.B. Blogger,
Unternehmen der sonstigen gewerblichen Wirtschaft, Rechtsanwaltskanzleien oder
private bzw. ehrenamtliche Nutzer. Die vorgeschlagene Regelung bedeutet damit
keine Änderung der Nutzungsmöglichkeiten andere Nutzer und für Verbraucher.
Ihre Rechte und Interessen werden durch das vorgeschlagene
Leistungsschutzrecht für Presseverleger nicht berührt.

Presseverlage können nur von Anbietern von Suchmaschinen die Unterlassung
unerlaubter Nutzungen verlangen und nur sie müssen für die Nutzung Lizenzen
erwerben. Dies gilt nicht für die reine Verlinkung und Nutzungen im Rahmen der
Zitierfreiheit.
## C. Alternativen

Keine.
## D. Haushaltsausgaben ohne Erfüllungsaufwand

Für Bund, Länder und Gemeinden sind keine Haushaltsausgaben ohne
Erfüllungsaufwand zu erwarten.
## E. Erfüllungsaufwand

Ein Erfüllungsaufwand im Sinne von § 2 des Gesetzes zur Einsetzung
eines nationalen Normenkontrollrates ist mit den vorgeschlagenen
Gesetzesänderungen nicht verbunden.
### E.1 Erfüllungsaufwand für Bürgerinnen und Bürger

Erfüllungsaufwand für Bürgerinnen und Bürger entsteht nicht.
### E.2 Erfüllungsaufwand für die Wirtschaft

Erfüllungsaufwand für die Wirtschaft entsteht nicht.

Davon Bürokratiekosten aus Informationspflichten
Bürokratiekosten aus Informationspflichten sind mit dem Entwurf
ebenfalls nicht verbunden.
### E.3 Erfüllungsaufwand der Verwaltung

Erfüllungsaufwand der Verwaltung ist mit dem Entwurf nicht
verbunden.
### F. Weitere Kosten

Keine.
## Begründung
### A. Allgemeiner Teil
#### I. Ziel und Gegenstand des Gesetzentwurfs

Der Gesetzentwurf sieht entsprechend den Vorgaben des Koalitionsvertrages die
Einführung eines Leistungsschutzrechts für Presseverlage vor. Damit soll
gewährleistet werden, dass Presseverlage im Online-Bereich nicht
schlechtergestellt sind als andere Werkvermittler; zugleich soll damit der
Schutz von Presseerzeugnissen im Internet verbessert werden.
#### II. Die wesentlichen Regelungen im Überblick

Mit der Einführung eines Leistungsschutzrechts für Presseverlage soll dem neu
entstandenen Schutzbedürfnis der Presseverleger Rechnung getragen werden. Die
Forderung nach dem Schutz der verlegerischen Leistung wurde schon im 19.
Jahrhundert erhoben. Schon damals beklagten Zeitungsverleger, dass
konkurrierende Blätter Artikel ohne eigene Recherche veröffentlichten und
damit die verlegerische Leistung anderer ausbeuteten. Vor der digitalen
Revolution war dem Schutzbedürfnis der Verleger durch den gesetzlichen Schutz
für die veröffentlichten Texte und Fotos hinreichend Rechnung getragen. Heute
sehen sich jedoch Presseverlage zunehmend damit konfrontiert, dass andere
gewerbliche Nutzer für die eigene Wertschöpfung systematisch auf die
verlegerische Leistung zugreifen und diese in einer Weise nutzen, die über das
bloße Verlinken weit hinausgeht. Angesichts dieser Entwicklung muss der
Gesetzgeber die wirtschaftlichen Interessen von Presseverlegern auf der einen
Seite und kommerziellen Nutzern auf der anderen Seite neu ausbalancieren. Die
Einführung eines neuen Leistungsschutzrechts darf jedoch nicht als ein
gesetzgeberischer Schutz von alten, überholten Geschäftsmodellen
missverstanden werden. Das neue Leistungsschutzrecht kann und soll kein
Korrektiv für Strukturveränderungen des Marktes sein, auf die Presseverleger
vor allem mit neuen Angeboten reagieren müssen.

Das neue Leistungsschutzrecht für Presseverleger, das neben dem bestehenden
rechtlichen Schutz der Urheber gewährt werden soll, wird auch den Belangen der
Urheber, d. h. vor allem der Journalisten, gerecht: Dies gewährleistet die
ausdrückliche Regelung des Verhältnisses beider Rechte in § 87g Absatz 3 des
Urheberrechtsgesetzes (UrhG), wonach das Leistungsschutzrecht des
Presseverlegers nicht zum Nachteil des Urhebers geltend gemacht werden kann.
Ferner gewährleistet § 87h UrhG die angemessene Beteiligung des Urhebers an
der Vergütung, die durch die Lizenzierung des neuen Leistungsschutzrechts
generiert wird. Die Einführung des Leistungsschutzrechts für Presseverlage
liegt damit wirtschaftlich auch im Interesse der am Presseerzeugnis
beteiligten Urheber.

Da geänderte Rahmenbedingungen für Presseverleger im Internet zugleich die
Rahmenbedingungen für die Internet-Nutzung insgesamt betreffen, soll das neue
Leistungsschutzrecht nur in dem begrenzten Umfang gewährleistet werden, wie
dies zum Schutz berechtigter verlegerischer Interessen erforderlich ist.
Erforderlich ist ein Schutz nur vor systematischen Zugriffen auf die
verlegerische Leistung durch die gewerblichen Anbieter von Suchmaschinen und
gewerbliche Anbieter von solchen Diensten im Netz, die Inhalte entsprechend
einer Suchmaschine aufbereiten. Denn deren Geschäftsmodell ist in besonderer
Weise darauf ausgerichtet, für die eigene Wertschöpfung auch auf die
verlegerische Leistung zuzugreifen. Erfasst sind also unabhängig von ihrer
technischen Ausgestaltung auch entsprechende Dienste, die nicht das gesamte
Internet durchsuchen, sondern lediglich einzelne, ausgewählte Bereiche
hiervon, also auch so genannte News-Aggregatoren, soweit sie nach Art einer
Suchmaschine ihre Treffer generieren oder ihre Ergebnisse darstellen.
Demgegenüber werden Dienste nicht erfasst, die die verlegerische Leistung auf
andere Weise nutzen, z. B. indem sie dem Internet-Nutzer aufgrund eigener
Wertung eine Auswahl von Presseerzeugnissen anzeigen. Auch Suchfunktionen
innerhalb des eigenen Datenbestandes werden vom Leistungsschutzrecht nicht
betroffen. Es gilt auch nicht für andere Nutzer, wie z.B. Unternehmen der
sonstigen gewerblichen Wirtschaft, Verbände, Rechtsanwalskanzleien, Blogger
oder private bzw. ehrenamtliche Nutzer. Die vorgeschlagene Regelung bedeutet
damit keine Änderung der Nutzungsmöglichkeiten anderer Nutzer und für
Verbraucher. Ihre Rechte und Interessen werden durch das vorgeschlagene
Leistungsschutzrecht für Presseverleger nicht berührt.

Der Informationsfluss im Internet wird durch die vorgeschlagene Regelung nicht
beeinträchtigt. Schon im Jahre 2003 hat der Bundesgerichtshof entschieden
(Urteil vom 17.07.2003, Az. I ZR 259/00 – „Paperboy“), dass eine bloße
Verlinkung keine Verletzung des Urheberrechts ist. Dies soll auch hinsichtlich
der Verletzung des neuen Leistungsschutzrechts für Presseverlage gelten. Das
neue Schutzrecht ermöglicht es also nicht, eine Verlinkung zu verbieten. Für
das Leistungsschutzrecht für Presseverleger sollen ferner auch die Schranken
des Urheberrechts gelten, also vor allem auch die Zitierfreiheit. Die
vorgeschlagene Regelung bedeutet damit keine Änderung der
Nutzungsmöglichkeiten für Verbraucher. Ihre Rechte und Interessen werden durch
das vorgeschlagene Leistungsschutzrecht für Presseverleger nicht berührt.

Mit der Einführung eines Leistungsschutzrechts für Presseverleger soll ferner
dem Umstand Rechnung getragen werden, dass sich mit dem Internet auch die
Möglichkeiten, Rechte von Presseverlegern zu verletzen, vervielfacht haben.
Dritte können Presseerzeugnisse ganz oder in Teilen innerhalb von wenigen
Sekunden vervielfältigen und selbst im Internet anbieten. Den Presseverlagen
wird ein eigenes Schutzrecht gewährt, das sie in die Lage versetzt, einfacher
und umfassender gegen Rechtsverletzungen im Internet vorzugehen.
Presseverleger müssen bei Verletzungshandlungen nun nicht mehr den komplexen
Nachweis der Rechtekette führen, sondern können unmittelbar aus eigenem Recht
vorgehen und insbesondere auch Unterlassungsansprüche geltend machen.
#### III. Gesetzgebungskompetenz

Die Gesetzgebungskompetenz des Bundes ergibt sich aus Artikel 73 Nummer 9 des
Grundgesetzes (Urheberrecht).
#### IV. Vereinbarkeit mit dem Recht der Europäischen Union und völkerrechtlichen Verträgen

Der Gesetzentwurf ist mit dem Recht der Europäischen Union und
völkerrechtlichen Verträgen, die die Bundesrepublik Deutschland abgeschlossen
hat, vereinbar.
#### V. Gesetzesfolgen
##### 1. Nachhaltigkeitsaspekte

Das Vorhaben berührt keine Aspekte einer nachhaltigen Entwicklung im Sinne der
nationalen Nachhaltigkeitsstrategie.
##### 2. Haushaltsausgaben ohne Erfüllungsaufwand

Für Bund, Länder und Gemeinden sind keine Haushaltsausgaben ohne
Erfüllungsaufwand zu erwarten.
##### 3. Erfüllungsaufwand

Ein Erfüllungsaufwand im Sinne von § 2 des Gesetzes zur Einsetzung eines
Nationalen Normenkontrollrates ist mit den vorgeschlagenen Gesetzesänderungen
nicht verbunden. Mit der Einführung eines Leistungsschutzrechts für
Presseverlage (§ 87f Absatz 1 Satz 1 UrhG) wird den Presseverlagen das
ausschließliche Recht eingeräumt, Presseerzeugnisse zu gewerblichen Zwecken im
Internet öffentlich zugänglich zu machen (Artikel 1 Nummer 2 des Entwurfs).
Schon bisher konnten Presseverlage Rechte in dem Umfang geltend machen, wie
sie ihnen durch die Urheber, d.h. insbesondere die Journalisten, vertraglich
eingeräumt worden waren. Künftig können Presseverlage auf der Grundlage eines
eigenen verwandten Schutzrechtes agieren.
##### 4. Weitere Kosten

Mit der Einführung des Leistungsschutzrechts für Presseverlage werden die
Presseverlage von gewerblichen Nutzern ein Entgelt für die Online-Nutzung von
Presseerzeugnissen verlangen können. Das zu erwartende Vergütungsaufkommen
lässt sich nicht beziffern. Ein signifikanter Anstieg des Preisniveaus und
damit auch des Verbraucherpreisniveaus wird nicht erwartet.
##### 5. Auswirkungen von gleichstellungspolitischer Bedeutung

Auswirkungen von gleichstellungspolitischer Bedeutung sind nicht zu erwarten.
### B. Besonderer Teil
#### Zu Artikel 1 (Änderung des Urheberrechtsgesetzes – UrhG)
##### Zu Nummer 1

Weil mit Abschnitt 7 neue Regelungen zum Schutz des Presseverlegers
in den Teil 2 des Urheberrechtsgesetzes eingefügt werden, war die
Inhaltsübersicht zu ergänzen.
##### Zu Nummer 42

Zu Abschnitt 7 (Schutz der Presseverleger) Zu § 87f § 87f Absatz 1
bestimmt, dass Rechtsinhaber des Leistungsschutzrechts der
Presseverleger ist. Er ist derjenige, der die wirtschaftlich-
organisatorische und technische Leistung erbringt, die für die
Publikation eines Presseerzeugnisses erforderlich ist, und er ist es
auch, der durch die gerade in der digitalen Welt leicht mögliche
gewerbliche Online-Nutzung des Presseerzeugnisses durch Dritte
geschädigt wird. Wie bei dem vergleichbaren Leistungsschutzrecht des
Tonträgerherstellers (§ 85 Absatz 1 Satz 2 UrhG) gilt auch hier, dass
der Presseverleger nicht ausschließlich eine natürliche Person ist,
die Presserzeugnisse herstellt. Vielmehr entsteht dann, wenn das
Presseerzeugnis in einem Unternehmen hergestellt wird, das
Leistungsschutzrecht bei dem Inhaber des Unternehmens. Maßgeblich ist
hier, wie auch bei der entsprechenden Regelung in § 85 Absatz 1 Satz
2 UrhG, wer den wirtschaftlichen Erfolg verantwortet und wem dieser
zuzurechnen ist.

Der Entwurf beschränkt sich darauf, dem Presseverleger ein
Leistungsschutzrecht hinsichtlich des Rechts der öffentlichen
Zugänglichmachung des Presseerzeugnisses einzuräumen. Es ist in
diesem Zusammenhang nicht erforderlich, die Frage zu entscheiden, die
gegenwärtig dem Bundesgerichtshof vorliegt (Az. I ZR 116/10,
"myvideo"), nämlich ob für die Online-Nutzung auch das
Vervielfältigungsrecht für den Upload auf den Server als selbständige
Nutzungshandlung lizenziert werden kann bzw. lizenziert werden muss.
Das Leistungsschutzrecht soll nach der Koalitionsvereinbarung die
Durchsetzung von Rechten im Internet gewährleisten. Dieser Schutz
wird schon dann gewährleistet, wenn die Presseverleger das Recht der
öffentlichen Zugänglichmachung (§ 19a UrhG) erhalten. Das
Vervielfältigungsrecht ist für den Schutz der Presseverleger im
Internet nicht notwendig.

Das Ausschließlichkeitsrecht des Presseverlegers als ein umfassendes
Verbotsrecht wird im Übrigen nur insoweit gewährt, als das
Presseerzeugnis – sei es unmittelbar oder mittelbar – zu gewerblichen
Zwecken öffentlich zugänglich gemacht wird. Abweichend vom
gewerbeoder steuerrechtlichen Gewerbebegriff erfasst Nutzung "zu
gewerblichen Zwecken" jede Nutzung, die mittelbar oder unmittelbar
der Erzielung von Einnahmen dient sowie jede Nutzung, die in
Zusammenhang mit einer Erwerbstätigkeit steht. Eine private Nutzung
von Presserzeugnissen im Internet beeinträchtigt das
Leistungsschutzrecht damit ebenso wenig wie die nichtgewerbliche
Nutzung durch die öffentliche Hand. Der Schutz, den Urheber und
sonstige Leistungsschutzberechtigte hinsichtlich ihrer Werke und
Schutzgegenständen gegen eine rechtswidrige Nutzung im Internet
genießen, bleibt jedoch in vollem Umfang erhalten und wird von dieser
Neuregelung nicht tangiert.

Das Leistungsschutzrecht schützt bereits kleine Teile des
Presseerzeugnisses. Hier kann nichts anderes gelten, als das, was der
Bundesgerichtshof mit Blick auf das Leistungsschutzrecht der
Tonträgerhersteller in seinem Urteil "Metall auf Metall" (Urteil vom
20. 11. 2008, Az. I ZR 112/06) ausgeführt hat. Ebenso wie beim
Leistungsschutzrecht des Tonträgerherstellers der Schutzgegenstand
nicht der Tonträger selbst ist, ist auch hier nicht das
Presseerzeugnis selbst Schutzgegenstand, sondern die zur Festlegung
des Presseerzeugnisses erforderliche wirtschaftliche,
organisatorische und technische Leistung des Presseverlegers. Die
unternehmerische Leistung umfasst jeden Teil des Presseerzeugnisses;
die erforderlichen Mittel müssen für einen kleinen Teil genauso
bereitgestellt werden wie für die gesamte Festlegung einer Ausgabe.
In diese unternehmerische Leistung greift auch derjenige ein, der nur
kleine Teile entnimmt.

Der Informationsfluss im Internet wird durch die vorgeschlagene
Regelung nicht beeinträchtigt. So wird eine bloße Verlinkung von dem
Leistungsschutzrecht nicht erfasst und bleibt weiterhin zulässig. Der
Bundesgerichtshof hat schon im Jahre 2003 entschieden (Urteil vom
17.07.2003, Az. I ZR 259/00 – "Paperboy"), dass durch das Setzen
eines Links auf eine vom Berechtigten öffentlich zugänglich gemachte
Webseite mit einem urheberrechtlich geschützten Werk nicht in das
Recht der öffentlichen Zugänglichmachung des Werkes eingegriffen
wird. Dies gilt ebenso für das neue Leistungsschutzrecht des
Presseverlegers.

Nach § 87f Absatz 2 knüpft das Leistungsschutzrecht an eine konkrete
Festlegung des Verlagsprodukts an, nämlich an das Presseerzeugnis als
Ausdruck der Verlegerleistung. Dabei kommt es nicht darauf an, auf
welche Art und Weise die Veröffentlichung erfolgt, ob also das
Presseerzeugnis lediglich offline, in elektronischer Form oder
kombiniert offline und online publiziert wird. Geschützt ist jedoch
nicht jede Festlegung. Die Festlegung muss vielmehr Teil einer
Sammlung journalistischer Beiträge sein, die nicht einmalig, sondern
fortlaufend unter einem Titel erscheint. Damit wird eine
redaktionelle Auswahl ebenso vorausgesetzt wie ein regelmäßiges
Erscheinen der journalistischen Beiträge. Eine bloße
Nachrichtenzusammenstellung ist daher vom Schutz nicht umfasst. Auch
Beiträge, die überwiegend der Eigenwerbung dienen, wie Publikationen
zur Kundenbindung bzw. Neukundengewinnung, genießen keinen Schutz.

Bei Internet-Blogs ist zu differenzieren. Sie gibt es in zahlreichen
Varianten. Wenn ein Blog sich als eine redaktionell ausgewählte
Sammlung journalistischer Beiträge darstellt, die fortlaufend unter
einem Titel erscheint, wird auch ein Blogger durch das neue
Leistungsschutzrecht geschützt und ist damit vergütungsberechtigt,
wenn andere seinen Blog nutzen. Ist z.B. ein Blogger hauptberuflich
als freiberuflicher Journalist tätig und setzt er sich auf seinem
Blog mit seinem Schwerpunktthema auseinander, dann handelt er, wenn
er hierbei Presseerzeugnisse von Dritten nutzt, zu gewerblichen
Zwecken. Wenn sich sein Blog als eine verlagstypische Leistung
darstellt, kommt der Blogger in den Genuss des neuen
Leistungsschutzrechts. Für die Online-Nutzung von Presserzeugnissen
Dritter muss er jedoch eine Lizenz erwerben.

Das Leistungsschutzrecht schützt das Presseerzeugnis in seiner
konkreten Festlegung und nicht die darin enthaltenen Schriftwerke
sowie sonstige Elemente wie Graphiken, Lichtbilder oder Bewegtbilder.
Der Schutz dieser Werke und Leistungsschutzgegenstände bestimmt sich
nach den geltenden Bestimmungen des Urheberrechtsgesetzes.
Presseverleger können dementsprechend weiterhin wegen einer
Verletzung der Urheberrechte bzw. sonstigen Leistungsschutzrechte
nach Maßgabe der Verträge zwischen den Urhebern bzw.
Leistungsschutzberechtigten auf der einen Seite und den
Presseverlegern auf der anderen Seite vorgehen.
#### Zu § 87g

Als vermögensrechtliches Leistungsschutzrecht ohne
persönlichkeitsrechtlichen Inhalt ist das Recht des Presseverlegers
verkehrsfähig und als Ganzes nach § 87g Absatz 1 übertragbar.
Insoweit gilt nichts anderes als für das Recht des Tonträgeroder
Filmherstellers. Satz 2 verweist wie auch die Regelungen anderer
Leistungsschutzrechte auf die §§ 31 und 33 UrhG und erklärt diese für
entsprechend anwendbar. Damit kann ein Presseverleger einem anderen
das Recht einräumen, das Presseerzeugnis auf einzelne oder alle der
ihm vorbehaltenen Nutzungsarten zu nutzen.

Die Schutzdauer ist in Absatz 2 geregelt. Hier erscheint die Dauer
von einem Jahr seit Veröffentlichung angemessen und ausreichend.

Das Recht des Presseverlegers an dem Presseerzeugnis entsteht
unbeschadet der hierin enthaltenen Rechte der Urheber und
Leistungsschutzberechtigten an den von ihnen geschaffenen Werken und
nach diesem Gesetz geschützten Schutzgegenständen. Nach Absatz 3 kann
das Leistungsschutzrecht nicht zum Nachteil der am Presseerzeugnis
beteiligten Urheber und Leistungsschutzberechtigten ausgeübt werden.
Den Urhebern und Leistungsschutzberechtigten ist es damit z. B.
weiterhin möglich, im Internet Eigenwerbung für von ihnen verfasste
Beiträge zu betreiben, ohne in das Leistungsschutzrecht einzugreifen.

Das Leistungsschutzrecht für Presseverleger wird – wie andere
Leistungsschutzrechte auch – nur im Rahmen von Schrankenregelungen
gewährleistet. Nach Absatz 4 Satz 1 ist es zulässig, Presserzeugnisse
zu nicht gewerblichen Zwecken öffentlich zugänglich zu machen. Dies
gilt selbstverständlich nicht für die Nutzung von urheberrechtlich
geschützten Werken, die in den Presserzeugnissen enthalten sind. Die
gesetzlich zulässige Nutzung beurteilt sich hier weiterhin nach den
hierfür maßgebenden Bestimmungen der §§ 44a ff.

Für die gesetzlich zulässige Nutzung des Leistungsschutzrechtes für
Presseverleger als Schutzgegenstand, ist hinsichtlich der Nutzung
durch Blogger wie folgt zu differenzieren: Wer z.B. einen Blog als
Hobby unentgeltlich und ohne Bezug zu seiner beruflichen Tätigkeit
betreibt, handelt nicht zu gewerblichen Zwecken. Er braucht daher
keine Lizenz für die Nutzung von Presseerzeugnissen und ist nicht
vergütungspflichtig. Diese Voraussetzungen werden viele Blogger
erfüllen. Ein Blog verfolgt auch nicht allein deshalb gewerbliche
Zwecke, weil er über Werbeeinblendungen des Hostanbieters Einnahmen
für diesen generiert. Nur wer fremde Presseerzeugnisse in Internet-
Blogs (zumindest teilweise) gewerblich nutzt, greift in das (neue)
Ausschließlichkeitsrecht des Presseverlegers ein, sieht sich daher
einem Unterlassungsanspruch ausgesetzt oder muss für die Nutzung eine
Lizenz erwerben.

Verwendet ein Blogger zu seinem Hobby-Blog Fachartikel aus
einschlägigen Presserzeugnissen und blendet er zur Refinanzierung
seiner Unkosten Werbebanner oder den Bezahl-Button eines
Micropaymentdienstes ein, dann handelt er zu gewerblichen Zwecken und
muss eine Lizenz erwerben. Darauf, ob der Blogger die Absicht hat,
mit der Werbung einen Gewinn zu erzielen, kommt es nicht an. Weil
sein Blog sich nicht als verlagstypische Leistung darstellt, gilt das
neue Leistungsschutzrecht für ihn nicht.

Ist ein Blogger ehrenamtlich für einen gemeinnützigen Verein tätig
und berichtet über die Vereinsaktivitäten, handelt er bei der Nutzung
zu gemeinnützigen, sozialen oder karitativen Zwecken und damit nicht
zu gewerblichen Zwecken. Der Blogger greift daher nicht in das
ausschließliche Recht der Presseverleger ein und ist insoweit nicht
vergütungspflichtig.

Im Übrigen sind nach Absatz 4 Satz 2 auf das Leistungsschutzrecht für
Presseverleger die Schrankenregelungen, die im Teil 1 Abschnitt 6 des
Urheberrechtsgesetzes das ausschließliche Recht des Urhebers
einschränken, entsprechend anwendbar. Damit bleibt insbesondere das
im Pressebereich wichtige Zitatrecht nach § 51 UrhG erhalten, sofern
die konkrete Festlegung als Grundlage des Zitats genutzt wird.
#### Zu § 87h

Die vorgeschlagene Regelung trägt auch den Interessen der Urheber
dadurch ausreichend Rechnung, dass sie ausdrücklich einen
Beteiligungsanspruch des Urhebers an der Verwertung des
Leistungsschutzrechts vorsieht. Damit wird die in den §§ 11 und 32
UrhG zum Ausdruck kommende verfassungsrechtlich begründete Wertung
bekräftigt, wonach

der Urheber an jeder wirtschaftlichen Nutzung seines Werkes
angemessen zu beteiligen ist.
#### Zu Artikel 32 (Inkrafttreten)

Artikel 2 regelt das Inkrafttreten des Gesetzes. Die Übergangsfrist
ermöglicht es der urheberrechtlichen Praxis, sich auf die neue
Rechtslage einzustellen.
