### PR TITLE
Haftungsfreistellung für öffentliche Funknetzwerke

### DIFF
--- a/t/tmg/index.md
+++ b/t/tmg/index.md
@@ -493,6 +493,14 @@ zur Durchführung der Übermittlung im Kommunikationsnetz geschieht und
 die Informationen nicht länger gespeichert werden, als für die
 Übermittlung üblicherweise erforderlich ist.
 
+(3) Der Ausschluss der Verantwortlichkeit (Absatz 1) umfasst auch gewerbliche und
+nichtgewerbliche Betreiber von Funknetzwerken, die sich an einen nicht im Voraus
+namentlich bestimmten Nutzerkreis richten (öffentliche Funknetzwerke).
+
+(4) Der Ausschluss der Verantwortlichkeit (Absatz 1) umfasst auch Ansprüche auf
+Unterlassung.
+
+
 
 ### § 9 Zwischenspeicherung zur beschleunigten Übermittlung von Informationen
 


### PR DESCRIPTION
### 1. Regelungsansatz

Die Rechtsprechung des Bundesgerichtshofs zur Haftung von Betreibern nicht
hinreichend gegen Mitnutzung geschützter (umso mehr also unverschlüsselter)
WLAN-Netze stützt sich bisher auf die Annahme eines Unterlassungsanspruchs. Der
BGH führt hierzu aus (vgl. BGH, Urteil vom 12. Mai 2010 - I ZR 121/08 - Sommer
unseres Lebens, Rn. 26 bis 29):

Als Störer kann bei der Verletzung absoluter Rechte auf Unterlassung in Anspruch
genommen werden, wer - ohne Täter oder Teilnehmer zu sein - in irgendeiner Weise
willentlich und adäquat kausal zur Verletzung des geschützten Rechts beiträgt ... Der
Betrieb eines nicht ausreichend gesicherten WLAN-Anschlusses ist adäquat kausal
für [Rechtsverletzungen], die unbekannte Dritte unter Einsatz dieses Anschlusses
begehen. Auch privaten Anschlussinhabern obliegen insoweit Prüfungspflichten,
deren Verletzung zu einer Störerhaftung führt ... Auch Privatpersonen, die einen
WLAN-Anschluss in Betrieb nehmen, ist es zuzumuten zu prüfen, ob dieser
Anschluss durch angemessene Sicherungsmaßnahmen hinreichend dagegen
geschützt ist, von außenstehenden Dritten für die Begehung von Rechtsverletzungen
missbraucht zu werden.

Soll also die Störerhaftung für Rechtsverletzungen über einen für Dritte geöffneten
WLAN-Zugang ausgeschlossen werden, so ist gesetzlich klarzustellen, dass
Betreiber von Netzen gerade nicht auf Unterlassung in Anspruch genommen werden
können, solange sie lediglich durch die – absichtliche oder auch nur fahrlässige –
Zurverfügungstellung eines Internet-Zugangs einen unwissentlichen Beitrag zu
fremden Rechtsverletzungen leisten.
### 2. zu § 8 Absatz 3 TMG-E

Der Entwurf stellt hier klar, dass auch Betreiber von öffentlichen WLANs als
Diensteanbieter im Sinne des § 8 TMG anzusehen sind, sodass die hier geregelten
Haftungsfreistellungen auch für sie gelten. § 8 TMG ist insbesondere auf Provider
zugeschnitten, umfasst jedoch auch andere „Diensteanbieter“, nämlich gem. § 2 Nr.
1 TMG alle natürlichen und juristischen Personen, die eigene oder fremde
Telemedien zur Nutzung bereithalten oder den Zugang zur Nutzung vermitteln.
Hierunter wären zwar bereits heute auch WLAN-Betreiber zu subsumieren, doch ist
dies bisher umstritten, sodass die notwendige Rechtssicherheit derzeit gerade nicht
herrscht. Insbesondere hat der BGH (a.a.O.) diese naheliegende Frage nicht
erkennbar geprüft, was die Notwendigkeit einer gesetzlichen Klarstellung
unterstreicht.

Insbesondere unter Wertungsgesichtspunkten kann es jedenfalls nicht überzeugen,
dass - wie derzeit faktisch - zwar große kommerzielle Provider von der
Haftungsfreistellung des § 8 TMG profitieren, nicht aber lokale InternetZugangsanbieter, die ein WLAN nichtkommerziell oder nur als begleitende
Dienstleistung etwa in einem Café, Restaurant oder einer Buchhandlung anbieten
("Mini-Provider"). Daher sollen sie ausdrücklich in den Anwendungsbereich des § 8
TMG einbezogen werden.
### 3. zu § 8 Absatz 4 TMG-E

Absatz 4 erstreckt die Haftungsregelung des Absatz 1 auf die sogenannte
Störerhaftung, indem er ausdrücklich eine Haftungsfreistellung auch für
Unterlassungsansprüche vorsieht.

§ 8 TMG eignet sich in besonderer Weise als Standort dieser Regelung. § 8 Absatz 1
TMG enthält bereits die Haftungsfreistellung für Diensteanbieter, die lediglich fremde
Informationen in einem Kommunikationsnetz übermitteln oder Zugang zur Nutzung
fremder Inhalte vermitteln. Sie ist damit insbesondere auf professionelle Provider
zugeschnitten, umfasst jedoch auch andere „Diensteanbieter“. Gem. § 2 Nr. 1 TMG
sind dies wiederum alle natürlichen und juristischen Personen, die eigene oder
fremde Telemedien zur Nutzung bereithalten oder den Zugang zur Nutzung
vermitteln, also auch private und kommerzielle Betreiber von Funknetzwerken. Durch
Absatz 3 in der Fassung dieses Entwurfs wird dies nochmals ausdrücklich
klargestellt.

Unklar ist aber bisher, inwieweit die Haftungsfreistellung aus § 8 Abs. 1 TMG auch
Unterlassungsansprüche ausschließt. Der BGH (a.a.O.) hat auch diese Frage nicht
geprüft, sondern geht allein auf den – fernliegenden, weil auf Hosting-Provider und
nicht auf Zugangsanbieter zugeschnittenen – § 10 TMG ein und bezeichnet diesen
(insoweit zutreffend) als nicht anwendbar.

Die bisherige Rechtsunsicherheit soll beseitigt werden, indem die
Haftungsfreistellung auch für Unterlassungsansprüche ausdrücklich geregelt wird.
Zugleich wird durch Absatz 3 des Entwurfs eindeutig klargestellt, dass auch die
Betreiber von WLANs als Diensteanbieter im Sinne des TMG anzusehen sind und
dass die Haftungsfreistellung nach § 8 Abs. 1 und Abs. 4 TMG auch für sie gilt.
