### PR TITLE
i4746: Änderung der Auslegung des Verkehrszeichen 276 ( Überholverbot )

### DIFF
--- a/s/stvo/index.md
+++ b/s/stvo/index.md
@@ -3950,7 +3950,7 @@ weiterhin die Lichtzeichen für Fußgänger beachten.
 
     *
     *   **Ge- oder Verbot**
-        Die nachfolgenden Zeichen 276 und 277 verbieten Kraftfahrzeugführern
+        Die nachfolgenden Zeichen 276 und 277 verbieten Führern von mehrspurigen Kraftfahrzeugen
         das Überholen von mehrspurigen Kraftfahrzeugen und Krafträdern mit
         Beiwagen.
         **Erläuterung**


### PR DESCRIPTION
https://lqfb.piratenpartei.de/lf/initiative/show/4746.html
